### PR TITLE
added 'return' in EventManager.py

### DIFF
--- a/EventManager.py
+++ b/EventManager.py
@@ -36,6 +36,7 @@ def remove_task(task_name):
         print(f"'{task_name}' has been removed from tasks.")
     else:
         print(f"'{task_name}' is not found in tasks.")
+        return
 
 # Function to remove an event
 def remove_event(event_name):
@@ -44,6 +45,8 @@ def remove_event(event_name):
         print(f"'{event_name}' has been removed from events.")
     else:
         print(f"'{event_name}' is not found in events.")
+        return
+
 
 # Main function
 def main():


### PR DESCRIPTION
If the user tries to remove a task or event that is not present in the organizer, the code does not handle this case properly. Currently, it prints a message saying the task/event is not found, but it doesn't exit the function, which could lead to misleading output.

To fix this, you can add a return statement after printing the "not found" message to exit the function and prevent further execution.